### PR TITLE
Remove noisy debug log

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@ impl ReqwestPlugin {
         mut requests: Query<(Entity, &mut ReqwestInflight)>,
     ) {
         for (entity, mut request) in requests.iter_mut() {
-            debug!("polling: {entity:?}");
             if let Some((result, parts)) = request.poll() {
                 match result {
                     Ok(body) => {


### PR DESCRIPTION
Removes this debug log that triggers every frame, saturating debug logs and making them useless.

If anything, this should be a trace log, but I would argue it's not a useful log to have operationally at all from what I can see. It seems more like a temporary `println!` you use for development, but remove before release.